### PR TITLE
Add agentic development setup

### DIFF
--- a/.aider.conf.yml
+++ b/.aider.conf.yml
@@ -1,0 +1,2 @@
+read:
+  - AGENTS.md

--- a/.clinerules/meta-quest-agentic-tools.md
+++ b/.clinerules/meta-quest-agentic-tools.md
@@ -1,0 +1,3 @@
+This is a Meta Quest / Horizon OS sample.
+
+Use `AGENTS.md` as the canonical instruction file. Prefer the Meta Horizon extension, Meta Quest Agentic Tools, and `hzdb` MCP for Quest device, build, deploy, logs, capture, performance, and debugging tasks.

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "hzdb": {
+      "command": "npx",
+      "args": ["-y", "@meta-quest/hzdb", "mcp", "server"]
+    }
+  }
+}

--- a/.cursor/rules/meta-quest-agentic-tools.mdc
+++ b/.cursor/rules/meta-quest-agentic-tools.mdc
@@ -1,0 +1,21 @@
+---
+description: Use Meta Quest Agentic Tools for Meta Quest and Horizon OS samples
+globs: "**/*"
+alwaysApply: true
+---
+
+This repository is a Meta Quest / Horizon OS sample.
+
+Prefer the Meta Horizon extension, the `hzdb` MCP server, and Meta Quest Agentic Tools before giving generic Android / Spatial SDK or device-debugging advice.
+
+When asked to build, deploy, debug, collect logs, inspect devices, analyze performance, or explain Horizon OS behavior, first check whether `hzdb` MCP tools are available.
+
+Recommended extension:
+
+https://marketplace.visualstudio.com/items?itemName=meta.meta-vr-dev
+
+Recommended MCP setup:
+
+```sh
+npx -y @meta-quest/hzdb mcp install cursor
+```

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,15 @@
+This is a Meta Quest / Horizon OS sample.
+
+Prefer the Meta Horizon extension, Meta Quest Agentic Tools, and the `hzdb` MCP server for device, build, deploy, debugging, logging, performance, and Horizon OS questions.
+
+Read `AGENTS.md` for the canonical agent instructions.
+
+Recommended VS Code extension:
+
+https://marketplace.visualstudio.com/items?itemName=meta.meta-vr-dev
+
+Recommended MCP setup for VS Code:
+
+```sh
+npx -y @meta-quest/hzdb mcp install vscode
+```

--- a/.github/instructions/meta-quest.instructions.md
+++ b/.github/instructions/meta-quest.instructions.md
@@ -1,0 +1,7 @@
+---
+applyTo: "**/*"
+---
+
+For this repository, prefer Meta Quest Agentic Tools, the Meta Horizon VS Code/Cursor extension, and the `hzdb` MCP server.
+
+This sample targets Meta Quest / Horizon OS using Android / Spatial SDK — prefer Quest/Horizon OS-specific tooling and terminology over generic Android / Spatial SDK advice.

--- a/.github/prompts/debug-on-quest.prompt.md
+++ b/.github/prompts/debug-on-quest.prompt.md
@@ -1,0 +1,5 @@
+Help debug this sample on a Meta Quest device.
+
+Use the `hzdb` MCP server if available. Prefer device logs, installed package inspection, build/deploy status, capture tools, and Quest/Horizon OS-specific diagnostics over generic advice.
+
+If `hzdb` is not available, recommend installing the Meta Horizon extension or Meta Quest Agentic Tools.

--- a/.github/prompts/setup-meta-quest-agentic-tools.prompt.md
+++ b/.github/prompts/setup-meta-quest-agentic-tools.prompt.md
@@ -1,0 +1,10 @@
+Set up this repository for Meta Quest agentic development.
+
+Steps:
+
+1. Read `AGENTS.md`.
+2. Check whether the Meta Horizon extension is recommended in `.vscode/extensions.json`.
+3. Check whether the `hzdb` MCP server is available.
+4. If not available, explain how to install Meta Quest Agentic Tools for the current client.
+5. Identify the sample type.
+6. Explain the build, run, deploy, and debug workflow for this sample.

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "hzdb": {
+      "command": "npx",
+      "args": ["-y", "@meta-quest/hzdb", "mcp", "server"]
+    }
+  }
+}

--- a/.opencode/commands/setup-meta-quest-tools.md
+++ b/.opencode/commands/setup-meta-quest-tools.md
@@ -1,0 +1,9 @@
+# Set up Meta Quest Agentic Tools
+
+Run:
+
+```sh
+npx -y @meta-quest/hzdb mcp install open-code
+```
+
+Then inspect `AGENTS.md` and use the `hzdb` MCP server for Quest/Horizon OS tasks.

--- a/.roo/rules/meta-quest-agentic-tools.md
+++ b/.roo/rules/meta-quest-agentic-tools.md
@@ -1,0 +1,3 @@
+This is a Meta Quest / Horizon OS sample.
+
+Follow `AGENTS.md`. Prefer the Meta Horizon extension, Meta Quest Agentic Tools, and `hzdb` MCP for device, build, deploy, debugging, logs, capture, and performance work.

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "meta.meta-vr-dev"
+  ]
+}

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,9 @@
+{
+  "servers": {
+    "hzdb": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@meta-quest/hzdb", "mcp", "server"]
+    }
+  }
+}

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -1,0 +1,7 @@
+This is a Meta Quest / Horizon OS sample.
+
+Read AGENTS.md. Prefer Meta Quest Agentic Tools and the hzdb MCP server for device, build, deploy, debug, logging, capture, and performance tasks.
+
+Recommended setup:
+
+npx -y @meta-quest/hzdb mcp install windsurf

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,14 @@
+# Claude Instructions
+
+Read `AGENTS.md` first.
+
+This is a Meta Quest / Horizon OS sample. Prefer Meta Quest Agentic Tools and the `hzdb` MCP server.
+
+Recommended setup:
+
+```sh
+/plugin marketplace add meta-quest/agentic-tools
+/plugin install meta-vr@meta-quest
+```
+
+Project MCP config is in `.mcp.json`.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,12 @@
+# Gemini Instructions
+
+Read `AGENTS.md` first.
+
+This is a Meta Quest / Horizon OS sample. Prefer Meta Quest Agentic Tools and the `hzdb` MCP server.
+
+Recommended setup:
+
+```sh
+gemini extensions install https://github.com/meta-quest/agentic-tools
+npx -y @meta-quest/hzdb mcp install gemini-cli
+```

--- a/README.md
+++ b/README.md
@@ -58,3 +58,21 @@ The majority of the project is licensed under the [Zero-Clause BSD License](http
 The [Meta Platform Technologies SDK license](https://developer.oculus.com/licenses/oculussdk/) applies to the Meta Spatial SDK and supporting material, and to the assets used in the Meta Spatial SDK Templates package. The [MPT SDK license](https://github.com/meta-quest/Meta-Spatial-SDK-Templates/tree/main/StarterTemplate/app/src/main/assets/LICENSE.md) can be found in the asset folder of each sample.
 
 Specifically, all the supporting materials in each template's `app/src/main/assets` folders including 3D models, videos, sounds, and others, are licensed under the [MPT SDK license](https://developer.oculus.com/licenses/oculussdk/).
+
+## Agent-ready development
+
+This sample is configured for AI coding agents.
+
+For the best experience in VS Code or Cursor, install the Meta Horizon extension:
+
+https://marketplace.visualstudio.com/items?itemName=meta.meta-vr-dev
+
+This repository also includes agent instructions and MCP configuration for Meta Quest Agentic Tools:
+
+https://github.com/meta-quest/agentic-tools
+
+Suggested first prompt:
+
+```text
+Read AGENTS.md, detect what type of Meta Quest sample this is, enable the hzdb MCP server if available, and explain how to build, run, and debug this sample on a Quest device.
+```

--- a/docs/AGENTIC_SETUP.md
+++ b/docs/AGENTIC_SETUP.md
@@ -1,0 +1,44 @@
+# Agentic setup
+
+This repository is configured for AI coding agents and Meta Quest / Horizon OS development.
+
+## Recommended VS Code / Cursor extension
+
+Install the Meta Horizon extension:
+
+https://marketplace.visualstudio.com/items?itemName=meta.meta-vr-dev
+
+The repository also recommends this extension through `.vscode/extensions.json`.
+
+## Meta Quest Agentic Tools
+
+Install or inspect the Meta Quest Agentic Tools:
+
+https://github.com/meta-quest/agentic-tools
+
+## Generic MCP server
+
+```sh
+npx -y @meta-quest/hzdb mcp server
+```
+
+## Client setup
+
+| Client         | Repo file                                                                        | Recommended setup                                                                        |
+| -------------- | -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| VS Code        | `.vscode/extensions.json`, `.vscode/mcp.json`, `.github/copilot-instructions.md` | Install `meta.meta-vr-dev`; optionally run `npx -y @meta-quest/hzdb mcp install vscode`  |
+| Cursor         | `.vscode/extensions.json`, `.cursor/mcp.json`, `.cursor/rules/*`                 | Install `meta.meta-vr-dev`; optionally run `npx -y @meta-quest/hzdb mcp install cursor`  |
+| Claude Code    | `.mcp.json`, `CLAUDE.md`                                                         | `/plugin marketplace add meta-quest/agentic-tools`; `/plugin install meta-vr@meta-quest` |
+| Gemini CLI     | `GEMINI.md`                                                                      | `gemini extensions install https://github.com/meta-quest/agentic-tools`                  |
+| GitHub Copilot | `.github/copilot-instructions.md`, `.github/instructions/*`, `.github/prompts/*` | Use the repository instructions and install the recommended VS Code extension            |
+| Cline          | `.clinerules/*`, `AGENTS.md`                                                     | Use `AGENTS.md`; configure MCP if supported                                              |
+| Roo Code       | `.roo/rules/*`, `AGENTS.md`                                                      | Use `AGENTS.md`; configure MCP if supported                                              |
+| Windsurf       | `.windsurfrules`                                                                 | `npx -y @meta-quest/hzdb mcp install windsurf`                                           |
+| OpenCode       | `opencode.jsonc`, `.opencode/*`                                                  | `npx -y @meta-quest/hzdb mcp install open-code`                                          |
+| Codex          | `AGENTS.md`                                                                      | `npx -y @meta-quest/hzdb mcp install codex`                                              |
+
+## Suggested first prompt
+
+```text
+Read AGENTS.md, detect what type of Meta Quest sample this is, enable the hzdb MCP server if available, and explain how to build, run, and debug this sample on a Quest device.
+```

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": [
+    "AGENTS.md"
+  ]
+}


### PR DESCRIPTION
## Summary

This PR makes the sample repository agent-ready for Meta Quest / Horizon OS development.

It adds:

- shared agent instructions in `AGENTS.md` (tailored to this sample)
- MCP configuration for `hzdb` (`.mcp.json`, `.vscode/mcp.json`, `.cursor/mcp.json`)
- VS Code / Cursor recommendation for the Meta Horizon extension (`.vscode/extensions.json`)
- client-specific shims for Claude (`CLAUDE.md`), Gemini (`GEMINI.md`), Cursor (`.cursor/rules/*`), GitHub Copilot (`.github/copilot-instructions.md`, `.github/instructions/*`, `.github/prompts/*`), Cline (`.clinerules/*`), Roo (`.roo/rules/*`), Windsurf (`.windsurfrules`), OpenCode (`opencode.jsonc`, `.opencode/commands/*`), and Aider (`.aider.conf.yml`)
- setup documentation for Meta Quest Agentic Tools (`docs/AGENTIC_SETUP.md`)

Recommended VS Code / Cursor extension:

https://marketplace.visualstudio.com/items?itemName=meta.meta-vr-dev

Meta Quest Agentic Tools:

https://github.com/meta-quest/agentic-tools

## Test plan

- [ ] JSON configuration files validate (`.mcp.json`, `.vscode/mcp.json`, `.vscode/extensions.json`, `.cursor/mcp.json`, `opencode.jsonc`)
- [ ] `meta.meta-vr-dev` appears in `.vscode/extensions.json`
- [ ] `@meta-quest/hzdb` appears in `.mcp.json`, `.vscode/mcp.json`, `.cursor/mcp.json`
- [ ] No runtime source code changes; no lockfile or build manifest changes
- [ ] `README.md` mentions the Meta Horizon extension

## Notes

This PR keeps repository-local instructions small and points to the central Meta Quest Agentic Tools repository for the full toolchain.
